### PR TITLE
Add terms block to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ When upgrading to this version, `ALLOWED_UNKNOWN_CONTENT_TYPES` must be set in t
 
 ## Added
 
+- base.html: Wrap default terms and conditions in template block so it can be overridden
 - utils.py: get_file_type_for_flatten_tool: consider content type too
 - settings.ALLOWED_UNKNOWN_CONTENT_TYPES.
 

--- a/libcoveweb2/templates/libcoveweb2/base.html
+++ b/libcoveweb2/templates/libcoveweb2/base.html
@@ -120,7 +120,9 @@
             {% endblock %}
           </ul>
           <ul class="text-muted">
+            {% block terms %}
             <li><a href="{% url 'terms' %}">{% trans "Terms &amp; Conditions" %}</a></li>
+            {% endblock %}
           </ul>
           {% comment %}Translators: Provides information about the version of the code base that is being used{% endcomment %}
           {% block version_link %}


### PR DESCRIPTION
Wrap default terms and conditions in template block so it can be overridden if necessary.