### PR TITLE
Specific JSON parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Changed
 
 - In `TaskWithState.process_get_state()` any changes to `process_data` are now ignored. https://github.com/OpenDataServices/lib-cove-web-2/issues/14
+- Provide a specific error when JSON parsing fails, rather than generic "There was an error."
 
 ## [0.3.0] - 2023-09-14
 

--- a/libcoveweb2/views.py
+++ b/libcoveweb2/views.py
@@ -149,17 +149,33 @@ class ExploreDataView(View):
 
     def view_data_has_error(self, request, supplied_data):
         """Called if the supplied data has any error set."""
-        return render(
-            request,
-            self.error_template,
-            {
-                "sub_title": _("Sorry, there was an error."),
-                "link": "index",
-                "link_text": _("Go to Home page"),
-                "msg": _("There was an error."),
-            },
-            status=500,
-        )
+        if supplied_data.error.startswith("JSON: Data parsing error"):
+            return render(
+                request,
+                self.error_template,
+                {
+                    "sub_title": _("Data parsing error."),
+                    "link": "index",
+                    "link_text": _("Go to Home page"),
+                    "msg": _(
+                        "The data is not valid JSON. "
+                        + "Use a JSON validator tool to correct your data."
+                    ),
+                },
+                status=500,
+            )
+        else:
+            return render(
+                request,
+                self.error_template,
+                {
+                    "sub_title": _("Sorry, there was an error."),
+                    "link": "index",
+                    "link_text": _("Go to Home page"),
+                    "msg": _("There was an error."),
+                },
+                status=500,
+            )
 
     def view_has_expired(self, request, supplied_data):
         """Called if the data has expired and has now been deleted.


### PR DESCRIPTION
Provide a specific error when JSON parsing fails, rather than generic "There was an error."